### PR TITLE
[#34] Fix apt-get in github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: >
+          sudo apt-get update &&
           sudo apt-get install gcc libkrb5-dev pass &&
           sudo pip install docker==5.0.3 docker-squash cekit odcs[client] packaging==21.3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: >
+          sudo apt-get update &&
           sudo apt-get install gcc libkrb5-dev pass &&
           sudo pip install docker==5.0.3 docker-squash cekit odcs[client] packaging==21.3
 


### PR DESCRIPTION
apt-get install may fail if it is used directly without update the mirror list with apt-get update

closes #34 