### PR TITLE
[#68] Improve Apache Artemis attribution in docs and metadata

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,6 @@
-# ArkMQ Broker container image
+# ArkMQ Broker container image powered by https://activemq.apache.org/components/artemis/[Apache Artemis]
+
+ArkMQ Broker is a container image for running https://activemq.apache.org/components/artemis/[Apache Artemis] messaging broker in containerized environments.
 
 ## License
 

--- a/image.yaml
+++ b/image.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 name: "arkmq-org/arkmq-org-broker"
-description: "ArkMQ Broker container image"
+description: "ArkMQ Broker is a container image for running Apache Artemis messaging broker in containerized environments"
 version: "2.0.10"
 from: "registry.access.redhat.com/ubi9/openjdk-17@sha256:615a2e789a3b2d982ec9e126d525697032440b1eace5dfea4fe6618cc85a7935"
 
@@ -10,6 +10,12 @@ labels:
     value: "ArkMQ Broker"
   - name: "maintainer"
     value: "ArkMQ <info@arkmq.org>"
+  - name: "org.opencontainers.image.title"
+    value: "ArkMQ Broker Powered by Apache Artemis"
+  - name: "org.opencontainers.image.description"
+    value: "ArkMQ Broker is a container image for running Apache Artemis messaging broker in containerized environments"
+  - name: "org.opencontainers.image.vendor"
+    value: "ArkMQ"
 
 envs:
   - name: "AMQ_HOME"

--- a/modules/apache-artemis-install/module.yaml
+++ b/modules/apache-artemis-install/module.yaml
@@ -7,7 +7,7 @@ artifacts:
     - name: apache-artemis-bin
       target: apache-artemis-bin.zip
       url: https://archive.apache.org/dist/artemis/artemis/2.51.0/apache-artemis-2.51.0-bin.zip
-      description: "Apache Artemis messaging broker"
+      description: "Apache Artemis distribution zip file"
       md5: 3b0da2ffb990423ff611fdfb25481b70
 execute:
     - script: install.sh


### PR DESCRIPTION
Enhanced references to Apache Artemis across documentation and container metadata to clarify that ArkMQ Broker is a container image for running Apache Artemis in containerized environments. Added OCI standard labels for better container registry display.