### PR TITLE
[#78] Set GID 0 for Kubernetes volumes

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -60,6 +60,8 @@ modules:
     - name: apache.artemis.install
     - name: apache.artemis.chown
 run:
-  user: 185
+  # The user is in the group 0 to have access to the volumes mounted
+  # by Kubernetes that are typically owned by UID 0 (root) and GID 0 (root).
+  user: "185:0"
   cmd:
     - "/opt/amq/bin/launch.sh"


### PR DESCRIPTION
Setting GID 0 (root group) allows containers running on Kubernetes to access files in mounted volumes that are typically owned by UID 0 (root) and GID 0 (root).